### PR TITLE
Ignore __REDUX_DEVTOOLS_EXTENSION__ for consumers of this package

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -52,6 +52,7 @@ const getPlugin = () => {
             const devTool =
               __DEV__ &&
               window.__REDUX_DEVTOOLS_EXTENSION__ &&
+              // $FlowFixMe
               __REDUX_DEVTOOLS_EXTENSION__();
 
             const enhancers = [enhancer, ctxEnhancer(ctx), devTool].filter(


### PR DESCRIPTION
Release verification fails for `fusion-rpc-redux` since `__REDUX_DEVTOOLS_EXTENSION__` cannot be resolved:

```
Found 1 error
Error ┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈ ../fusion-plugin-react-redux/src/browser.js:55:15

Cannot resolve name __REDUX_DEVTOOLS_EXTENSION__.

     52│             const devTool =
     53│               __DEV__ &&
     54│               window.__REDUX_DEVTOOLS_EXTENSION__ &&
     55│               __REDUX_DEVTOOLS_EXTENSION__();
     56│
     57│             const enhancers = [enhancer, ctxEnhancer(ctx), devTool].filter(
     58│               Boolean

Found 1 error
error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
exec Errored while executing 'yarn flow check' in 'fusion-rpc-redux'
error Command failed with exit code 2.
```