### PR TITLE
Update Token types and add sanity test

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "eslint-plugin-react": "7.7.0",
     "flow-bin": "^0.71.0",
     "fusion-core": "^1.2.6",
+    "fusion-test-utils": "^1.0.5",
     "fusion-tokens": "^1.0.3",
     "nyc": "^11.7.1",
     "prettier": "^1.12.1",

--- a/src/__tests__/index.node.js
+++ b/src/__tests__/index.node.js
@@ -8,10 +8,14 @@
 
 import tape from 'tape-cup';
 import React from 'react';
+import type {Reducer, StoreEnhancer} from 'redux';
 
-import {consumeSanitizedHTML} from 'fusion-core';
+import App, {consumeSanitizedHTML, createPlugin} from 'fusion-core';
+import type {FusionPlugin} from 'fusion-core';
+import {getSimulator} from 'fusion-test-utils';
 
 import Redux from '../index.js';
+import {EnhancerToken, ReducerToken, ReduxToken} from '../tokens.js';
 
 tape('interface', async t => {
   const ctx = {memoized: new Map()};
@@ -107,6 +111,69 @@ tape('enhancers', async t => {
 
   const store = await redux.initStore();
   t.equals(store.ctx, mockCtx, '[Final store] ctx provided by ctxEnhancer');
+  t.end();
+});
+
+const testEnhancer = async (
+  t: tape$Context,
+  enhancer: StoreEnhancer<*, *, *> | FusionPlugin<*, StoreEnhancer<*, *, *>>
+): Promise<void> => {
+  const app = new App('el', el => el);
+  const mockReducer: Reducer<*, *> = s => s;
+
+  app.register(EnhancerToken, enhancer);
+  app.register(ReducerToken, mockReducer);
+  app.register(ReduxToken, Redux);
+
+  const testPlugin = createPlugin({
+    deps: {
+      redux: ReduxToken,
+    },
+    middleware({redux}) {
+      return async (ctx, next) => {
+        const reduxScoped = redux.from(ctx);
+
+        if (!reduxScoped.initStore) {
+          t.fail();
+          t.end();
+          return;
+        }
+
+        const store = await reduxScoped.initStore();
+        // $FlowFixMe
+        t.equals(store.mock, true, '[Final store] ctx provided by ctxEnhancer');
+
+        return next();
+      };
+    },
+  });
+  app.register(testPlugin);
+
+  const simulator = getSimulator(app);
+  await simulator.render('/');
+};
+
+tape('enhancers - via app.register', async t => {
+  /* Enhancer function */
+  const myEnhancer: StoreEnhancer<*, *, *> = createStore => (...args) => {
+    const store = createStore(...args);
+    // $FlowFixMe
+    store.mock = true;
+    return store;
+  };
+  await testEnhancer(t, myEnhancer);
+
+  /* Enhancer plugin */
+  const myEnhancerPlugin: FusionPlugin<
+    *,
+    StoreEnhancer<*, *, *>
+  > = createPlugin({
+    provides() {
+      return myEnhancer;
+    },
+  });
+  await testEnhancer(t, myEnhancerPlugin);
+
   t.end();
 });
 

--- a/src/browser.js
+++ b/src/browser.js
@@ -54,7 +54,6 @@ const getPlugin = () => {
               window.__REDUX_DEVTOOLS_EXTENSION__ &&
               // $FlowFixMe
               __REDUX_DEVTOOLS_EXTENSION__();
-
             const enhancers = [enhancer, ctxEnhancer(ctx), devTool].filter(
               Boolean
             );

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -9,15 +9,15 @@
 import type {Reducer, StoreEnhancer, Store} from 'redux';
 
 import {createToken} from 'fusion-core';
-import type {FusionPlugin, Token, Context} from 'fusion-core';
+import type {Token, Context} from 'fusion-core';
 
-import type {ReactReduxDepsType, ReactReduxServiceType} from './types.js';
+import type {ReactReduxServiceType} from './types.js';
 
 type InitialStateType<S, A, D> = (ctx?: Context) => Promise<Store<S, A, D>>;
 
-export const ReduxToken: Token<
-  FusionPlugin<ReactReduxDepsType, ReactReduxServiceType>
-> = createToken('ReduxToken');
+export const ReduxToken: Token<ReactReduxServiceType> = createToken(
+  'ReduxToken'
+);
 export const ReducerToken: Token<Reducer<*, *>> = createToken('ReducerToken');
 export const PreloadedStateToken: Token<Object> = createToken(
   'PreloadedStateToken'

--- a/yarn.lock
+++ b/yarn.lock
@@ -970,7 +970,7 @@ assert-plus@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-0.2.0.tgz#d74e1b87e7affc0db8aadb7021f3fe48101ab234"
 
-assert@^1.1.1:
+assert@^1.1.1, assert@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/assert/-/assert-1.4.1.tgz#99912d591836b5a6f5b345c0f07eefc08fc65d91"
   dependencies:
@@ -2601,6 +2601,14 @@ fusion-core@^1.2.6:
     toposort "^1.0.6"
     ua-parser-js "^0.7.17"
     uuid "^3.2.1"
+
+fusion-test-utils@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/fusion-test-utils/-/fusion-test-utils-1.0.5.tgz#6ac2d2af57e7201b4c6e3e13ac2524d423e8e4c7"
+  dependencies:
+    assert "^1.4.1"
+    koa "^2.4.1"
+    node-mocks-http "^1.6.6"
 
 fusion-tokens@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
Changes to the `Token` types to leverage the idea that `Token<FusionPlugin<*, Service>>` will resolve to the `Service` and not the plugin.