### PR TITLE
Use required context parameter for InitialStateType

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ A function that gets initial state asynchronously without triggering actions. Op
 ###### Types
 
 ```flow
-type InitialState = () => Promise<State> | State
+type InitialState = (ctx: Context) => Promise<State> | State
 ```
 
 ---

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -26,5 +26,5 @@ export const EnhancerToken: Token<StoreEnhancer<*, *, *>> = createToken(
   'EnhancerToken'
 );
 export const GetInitialStateToken: Token<
-  InitialStateType<Object>  
+  InitialStateType<Object>
 > = createToken('GetInitialStateToken');

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -13,7 +13,7 @@ import type {Token, Context} from 'fusion-core';
 
 import type {ReactReduxServiceType} from './types.js';
 
-type InitialStateType<TState> = (ctx?: Context) => Promise<TState> | TState;
+type InitialStateType<TState> = (ctx: Context) => Promise<TState> | TState;
 
 export const ReduxToken: Token<ReactReduxServiceType> = createToken(
   'ReduxToken'
@@ -26,5 +26,5 @@ export const EnhancerToken: Token<StoreEnhancer<*, *, *>> = createToken(
   'EnhancerToken'
 );
 export const GetInitialStateToken: Token<
-  InitialStateType<Object>
+  InitialStateType<Object>  
 > = createToken('GetInitialStateToken');


### PR DESCRIPTION
This fixes a potential flow warning if developers attempt to use a custom method for GetInitialStateToken.

Also fixes the documentation to reflect this required parameter.