### PR TITLE
Remove unused @types/redux

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   },
   "devDependencies": {
     "@babel/preset-react": "7.0.0-beta.52",
-    "@types/redux": "3.6.31",
     "babel-eslint": "^8.2.3",
     "create-universal-package": "3.4.4",
     "enzyme": "3.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -898,10 +898,6 @@
   version "9.4.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-9.4.1.tgz#0f636f7837e15d2d73a7f6f3ea0e322eb2a5ab65"
 
-"@types/redux@3.6.31":
-  version "3.6.31"
-  resolved "https://registry.yarnpkg.com/@types/redux/-/redux-3.6.31.tgz#40eafa7575db36b912ce0059b85de98c205b0708"
-
 "@types/rimraf@^0.0.28":
   version "0.0.28"
   resolved "https://registry.yarnpkg.com/@types/rimraf/-/rimraf-0.0.28.tgz#5562519bc7963caca8abf7f128cae3b594d41d06"


### PR DESCRIPTION
Fixes https://github.com/fusionjs/fusion-plugin-react-redux/issues/135

Unsure why we need these TypeScript definitions in the first place. Removing them doesn't seem to cause any issues with flow (obviously) and testing the package.

If we want to keep it around, `3.6.31` is actually fine, just not `3.6.0` so not sure why Renovate is attempting to use `3.6.0` when we pin to `3.6.31`. If we want to keep this as a devDep then we may need to add the package to Renovate configuration as an ignored package then.