### PR TITLE
Fix missing cleanup method in plugin's browser env definition

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -81,6 +81,9 @@ const getPlugin = () => {
         return next();
       };
     },
+    cleanup: async () => {
+      storeCache = null;
+    },
   });
 };
 


### PR DESCRIPTION
**Bug:**
 - If a test suite has multiple simulator tests - `ReactReduxPlugin` is returning the redux store created during the first test, as store for all the subsequent tests.
- Effectively the redux state at the end of the previous test becomes the initial state of the app in next test.

**RootCause:**
- Due to absence of cleanup logic of `storeCache` the first created store is being returned for all subsequent tests despite mentions of `app.cleanup()` in each test

**Fix:** 
- Added `cleanup` method to the browser env's plugin definition assigning the `storeCache` closure variable to `null`.