### PR TITLE
Export GetInitialStateType

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,8 @@ import serverPlugin from './server';
 
 export default (__NODE__ ? serverPlugin : browserPlugin());
 
+export type {GetInitialStateType} from './types';
+
 export {
   ReduxToken,
   ReducerToken,

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -9,11 +9,9 @@
 import type {Reducer, StoreEnhancer} from 'redux';
 
 import {createToken} from 'fusion-core';
-import type {Token, Context} from 'fusion-core';
+import type {Token} from 'fusion-core';
 
-import type {ReactReduxServiceType} from './types.js';
-
-type InitialStateType<TState> = (ctx: Context) => Promise<TState> | TState;
+import type {GetInitialStateType, ReactReduxServiceType} from './types.js';
 
 export const ReduxToken: Token<ReactReduxServiceType> = createToken(
   'ReduxToken'
@@ -26,5 +24,5 @@ export const EnhancerToken: Token<StoreEnhancer<*, *, *>> = createToken(
   'EnhancerToken'
 );
 export const GetInitialStateToken: Token<
-  InitialStateType<Object>
+  GetInitialStateType<Object>
 > = createToken('GetInitialStateToken');

--- a/src/types.js
+++ b/src/types.js
@@ -17,6 +17,10 @@ import {
   GetInitialStateToken,
 } from './tokens.js';
 
+export type GetInitialStateType<TState> = (
+  ctx: Context
+) => Promise<TState> | TState;
+
 export type StoreWithContextType<S, A, D> = Store<S, A, D> & {ctx: Context};
 
 export type ReactReduxDepsType = {


### PR DESCRIPTION
This is needed so applications can annotate their GetInitialState plugin generics properly.