### PR TITLE
Constrain react-redux to <6

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "peerDependencies": {
     "fusion-core": "^1.10.1",
     "react": "14.x - 16.x",
-    "react-redux": ">=5.0.6",
+    "react-redux": ">=5.0.6 <6",
     "redux": ">=4.0.0"
   },
   "scripts": {


### PR DESCRIPTION
Adding version constraints since react-redux v6 isn't support.